### PR TITLE
fix: Load Flowcells "Apply to All" not persisting loading concentration/PhiX values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Unreleased
 ==========
 
+- Fix Load Flowcells' "Apply to All" context menu action (loading concentration, PhiX %) writing the value into the grid without actually saving it to the database, because the underlying Tabulator row update doesn't trigger the per-cell save hook.
 - CI: after the weekly dependency-update workflow bumps GitHub Action major versions, `zizmor --fix` re-pins those `uses:` refs to commit SHAs (with the resolved tag as a comment), so the update PR never reintroduces floating version tags.
 - `GET /api/internal_pis/` now transliterates PI names the same way dissectBCL's `umlautDestroyer` turns them into on-disk folder tokens (accents/umlauts stripped, spaces removed) before matching. Previously an accented or spaced PI name (e.g. "Cissé", "AlHaj Abed") would never match the already-transliterated folder name dissectBCL derives, silently routing them as external instead of using their `deliver_to` override.
 - Data migration: transliterate German umlauts (ä/ö/ü/ß) in existing `User.first_name`/`last_name` values to their ASCII digraph form (e.g. ö -> oe), so they can no longer mismatch a filesystem-derived token once umlaut-aware matching is in place elsewhere.

--- a/frontend/src/constants/loadFlowcellsConsts.js
+++ b/frontend/src/constants/loadFlowcellsConsts.js
@@ -46,7 +46,11 @@ export function loadFlowcellsGroupHeader(value, rows = []) {
 }
 
 export function loadFlowcellsColumnDefs(getTabulatorInstance, callbacks = {}) {
-  const { onToggleSelected = () => {}, onPoolClick = () => {} } = callbacks;
+  const {
+    onToggleSelected = () => {},
+    onPoolClick = () => {},
+    onApplyToAll = null
+  } = callbacks;
 
   const columns = [
     {
@@ -216,7 +220,8 @@ export function loadFlowcellsColumnDefs(getTabulatorInstance, callbacks = {}) {
     allowCopy: true,
     allowEdit: true,
     allowApplyToAll: true,
-    skipFields: new Set(["selected", "pool_name"])
+    skipFields: new Set(["selected", "pool_name"]),
+    onApplyToAll
   });
 }
 

--- a/frontend/src/views/loadFlowcellsView.vue
+++ b/frontend/src/views/loadFlowcellsView.vue
@@ -847,7 +847,8 @@ import {
   buildExcelDownloadFilename,
   formatDisplayDate,
   isSupportedExcelTemplateFile,
-  isValidDate
+  isValidDate,
+  applyValueToAllRows
 } from "../utilities/utilityFunctions";
 import {
   loadFlowcellsGroupHeader,
@@ -1160,7 +1161,8 @@ export default {
       );
       const columns = loadFlowcellsColumnDefs(() => this.tabulatorInstance, {
         onToggleSelected: this.handleRowSelectionToggle,
-        onPoolClick: this.openPoolInfoPopup
+        onPoolClick: this.openPoolInfoPopup,
+        onApplyToAll: this.handleApplyToAllFromContext
       });
       this.columnsList = columns.map((column) => {
         if (!column.field) return column;
@@ -1534,6 +1536,21 @@ export default {
         delete this.pendingLaneChanges[pk];
       }
       this.scheduleBatchSave();
+    },
+    handleApplyToAllFromContext(payload = {}) {
+      const { cell, field, tableRef } = payload;
+      if (!cell || !field || !tableRef) return;
+      applyValueToAllRows(cell, () => tableRef, {
+        blockActionsOnDisabledCells: false
+      });
+      // row.update() (used by applyValueToAllRows) does not fire Tabulator's
+      // cellEdited event, so affected rows must be queued for saving here.
+      tableRef.getRows().forEach((row) => {
+        const targetCell = row.getCell(field);
+        if (targetCell) {
+          this.handleCellEdited(targetCell);
+        }
+      });
     },
     scheduleBatchSave() {
       if (this.pendingEditTimer) {


### PR DESCRIPTION
## Summary
- "Apply to All" on the Loading Concentration / PhiX % columns in Load Flowcells wrote the value into the grid for every lane, but only ever saved the lane whose cell was directly edited — the value silently reverted on reload for every other lane.
- Root cause: the default apply-to-all handler updates rows via Tabulator's `row.update()`, which doesn't fire the `cellEdited` event that the view relies on to queue a row for its debounced save request.
- Fix wires an `onApplyToAll` callback into `loadFlowcellsColumnDefs` (mirroring the existing pattern in `requestEditorConsts.js`/`requestEditorView.vue`) so every row affected by "Apply to All" also gets queued and saved, not just the originally-edited one.

## Test plan
- [x] `npm run build` (inside `parkour2-vite`) compiles cleanly
- [x] `eslint` on the changed files shows no new warnings/errors vs. base
- [x] Deployed to `parkour-dev`, logged in, expanded a real flowcell (HNHMNDRX7, 2 lanes), edited Lane 1's Loading Concentration, ran "Apply to All", reloaded the page, and confirmed via the UI **and** a direct `psql` query against `flowcell_lane` that both lanes persisted the new value. Test values were reverted back to their originals afterward.

Fixes Vikunja #421.