### PR TITLE
fix: Usage 'Libraries & Samples' chart showing empty grid instead of 'No Data'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Unreleased
 ==========
 
+- Fix Usage page's "Libraries & Samples" chart showing an empty grid instead of "No Data" for a date range with zero records — its API endpoint always returns a `Libraries`/`Samples` row even when both are zero, so the empty-state check needs to sum the values, not just check the array isn't empty.
+
 - Usage page: replace the legacy ExtJS pie charts (built on `Ext.chart.*`) with a new Vue page using ECharts bar charts (phase 1 of removing the ExtJS shell) — same four breakdowns (Libraries & Samples, Organizations, Principal Investigators, Analysis Types) and date-range filter, same underlying API.
 - Move the shared logo image (used in PDFs, approval/message/password emails) from `static/main-hub/resources/images/` to `static/images/`, ahead of removing the legacy ExtJS main-hub shell (phase 0 of that migration) — those references would otherwise have silently broken once main-hub is deleted.
 - Fix Load Flowcells' "Apply to All" context menu action (loading concentration, PhiX %) writing the value into the grid without actually saving it to the database, because the underlying Tabulator row update doesn't trigger the per-cell save hook.

--- a/frontend/src/constants/usageConsts.js
+++ b/frontend/src/constants/usageConsts.js
@@ -40,6 +40,22 @@ export const USAGE_CHARTS = [
   }
 ];
 
+// The API always returns one row per known category (e.g. "records"
+// always returns both "Libraries" and "Samples"), even when every value in
+// range is zero -- so an empty range still yields a non-empty array. Sum
+// the actual values instead of checking array length to decide whether
+// there's anything to plot.
+export function usageChartTotal(chartDef, data) {
+  return data.reduce((sum, row) => {
+    return (
+      sum +
+      (chartDef.stacked
+        ? (row.libraries || 0) + (row.samples || 0)
+        : row.data || 0)
+    );
+  }, 0);
+}
+
 export function buildUsageChartOption(chartDef, data) {
   const names = data.map((row) => row.name);
 

--- a/frontend/src/views/usageView.vue
+++ b/frontend/src/views/usageView.vue
@@ -72,7 +72,11 @@ import {
   isValidDate,
   urlStringStartsWith
 } from "../utilities/utilityFunctions";
-import { USAGE_CHARTS, buildUsageChartOption } from "../constants/usageConsts";
+import {
+  USAGE_CHARTS,
+  buildUsageChartOption,
+  usageChartTotal
+} from "../constants/usageConsts";
 import iconUsageHeader from "../assets/icons/header_usage.svg";
 
 use([
@@ -119,7 +123,8 @@ export default {
     });
 
     function chartHasData(key) {
-      return (chartData[key] || []).length > 0;
+      const chartDef = usageCharts.find((c) => c.key === key);
+      return usageChartTotal(chartDef, chartData[key] || []) > 0;
     }
 
     async function loadUsageData() {


### PR DESCRIPTION
## Summary
Found while going back to verify PR #330's test plan before starting phase 2. The Usage page's "Libraries & Samples" chart (`api/usage/records/`) always returns exactly two rows — `Libraries` and `Samples` — even when both are zero for the selected date range, unlike the other three charts which only include entries that actually have data. The "No Data" empty-state check only tested array length, so this one chart rendered an empty grid instead of "No Data" for a range with no records.

Fix: sum the actual plotted values (not just check array length) to decide whether there's anything to show. New `usageChartTotal()` helper in `usageConsts.js`, reused by `usageView.vue`'s `chartHasData()`.

## Test plan
- [x] A date range with zero records now shows "No Data" on all four charts (verified on parkour-dev: previously 3/4, now 4/4)
- [x] A date range with real data still renders all four charts correctly (unaffected by this change)