### PR TITLE
fix: include Index Type in Libraries & Samples search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Unreleased
 ==========
 
+- Fixed Libraries & Samples search returning no results for an Index Type that exists in the data: the global search endpoint never queried `index_type_name`.
 - Fix notification email header logo: it still used an old brand mark (an "S"-swirl) at a distorted 17x26px size; replaced with the current DNA-helix mark used elsewhere in the app, sized 24x24.
 - Top nav bar: restyled (teal brand + beige bar, pill buttons), several labels shortened/renamed (Incoming, Load FCs, Stats), Usage moved under the Stats dropdown with its own icon, dropdown-clipping bug fixed, user actions stacked into two rows (name above Duties/Admin/Logout), the Stats dropdown button got its old chart-line icon back with Primary/Secondary now using microscope/magnifying-glass icons, and buttons collapse to icon-only when the bar actually runs out of room (not a fixed viewport breakpoint).
 - Removed the legacy ExtJS shell: cut over to a native Vue app shell/nav, migrated the Usage charts to Vue/ECharts, dropped the dead iframe-bridge code, and deleted `backend/static/main-hub` and its leftover Makefile/template references.

--- a/backend/library/tests.py
+++ b/backend/library/tests.py
@@ -270,6 +270,12 @@ class TestLibrarySampleTree(BaseTestCase):
             gated_flowcell_queries[0].children,
         )
 
+    def test_search_query_includes_index_type_name(self):
+        """Index Type values must be searchable like other displayed fields."""
+        query = build_search_term_query("Nextera XT")
+
+        self.assertIn(("index_type_name__icontains", "Nextera XT"), query.children)
+
     def test_sequencer_filter_is_limited_to_sequencing_statuses(self):
         """Sequencer filtering applies the same status gate as displayed data."""
         queryset = Mock()

--- a/backend/library/views.py
+++ b/backend/library/views.py
@@ -85,6 +85,7 @@ def build_search_term_query(term):
         "barcode__icontains",
         "request_name__icontains",
         "pool_names__icontains",
+        "index_type_name__icontains",
     ]
     field_queries = [Q(**{field: term}) for field in search_fields]
     field_queries.append(


### PR DESCRIPTION
## Summary
- The Libraries & Samples global search endpoint's field list (`build_search_term_query` in `backend/library/views.py`) never included `index_type_name`, so searching for an Index Type value (e.g. "Nextera XT (I7: N701-N729, I5: S501-S522)" or "Pico Methyl-Seq Library Prep Kit") returned no results even though matching records exist.
- The Index Type column's Tabulator header filter is client-side only and matches just the currently loaded page, which is why it also silently misses older/out-of-page records — reported alongside this bug. This PR fixes the backend global search gap; the header-filter behavior is a separate, broader limitation shared by other columns and is out of scope here.
- Added `index_type_name__icontains` to the search field list and a regression test.

## Test plan
- [x] `python manage.py test library.tests.TestLibrarySampleTree` — 6/6 passing
- [x] Manually verify in a deployed environment that searching "Nextera XT" / "Pico Methyl-Seq Library Prep Kit" in the Libraries & Samples search box now returns matching rows
