### PR TITLE
feat: add I7/I5 Index range filters to Libraries and Samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Unreleased
 ==========
 
+- Added I7 Index / I5 Index range filters (From/To) to Libraries & Samples Advanced Filters, so users can find libraries/samples by index ID range (e.g. N701 to N729) without relying on exact Index Type name matches.
 - Fix notification email header logo: it still used an old brand mark (an "S"-swirl) at a distorted 17x26px size; replaced with the current DNA-helix mark used elsewhere in the app, sized 24x24.
 - Top nav bar: restyled (teal brand + beige bar, pill buttons), several labels shortened/renamed (Incoming, Load FCs, Stats), Usage moved under the Stats dropdown with its own icon, dropdown-clipping bug fixed, user actions stacked into two rows (name above Duties/Admin/Logout), the Stats dropdown button got its old chart-line icon back with Primary/Secondary now using microscope/magnifying-glass icons, and buttons collapse to icon-only when the bar actually runs out of room (not a fixed viewport breakpoint).
 - Removed the legacy ExtJS shell: cut over to a native Vue app shell/nav, migrated the Usage charts to Vue/ECharts, dropped the dead iframe-bridge code, and deleted `backend/static/main-hub` and its leftover Makefile/template references.

--- a/backend/library/tests.py
+++ b/backend/library/tests.py
@@ -25,9 +25,12 @@ from library.ro_crate import (
 from library.ro_crate_html import RO_CRATE_HTML_PREVIEW_NAME, generate_html_preview
 from library.views import (
     SEQUENCING_STATUSES,
+    InvalidIndexRangeError,
     apply_stage_data_visibility,
+    build_index_range_filter,
     build_search_term_query,
     filter_by_sequencer,
+    parse_index_id,
 )
 from library_preparation.models import LibraryPreparation
 from library_sample_shared.models import (
@@ -282,6 +285,50 @@ class TestLibrarySampleTree(BaseTestCase):
             status__in=SEQUENCING_STATUSES,
             sequencer_ids__contains=[7],
         )
+
+    def test_parse_index_id_splits_prefix_and_number(self):
+        self.assertEqual(parse_index_id("N701"), ("N", 701))
+        self.assertEqual(parse_index_id("RPI10"), ("RPI", 10))
+
+    def test_parse_index_id_rejects_unrecognized_shape(self):
+        self.assertEqual(parse_index_id("N701A"), (None, None))
+        self.assertEqual(parse_index_id(""), (None, None))
+
+    def test_index_range_filter_expands_numeric_range(self):
+        """Ranges are expanded to literal IDs, not compared as strings."""
+        query = build_index_range_filter("i7_id", "I7 Index", "RPI1", "RPI10")
+        self.assertEqual(
+            query,
+            Q(i7_id__in=[f"RPI{n}" for n in range(1, 11)]),
+        )
+
+    def test_index_range_filter_accepts_reversed_bounds(self):
+        query = build_index_range_filter("i5_id", "I5 Index", "S522", "S501")
+        self.assertEqual(
+            query,
+            Q(i5_id__in=[f"S{n}" for n in range(501, 523)]),
+        )
+
+    def test_index_range_filter_single_bound_is_exact_match(self):
+        self.assertEqual(
+            build_index_range_filter("i7_id", "I7 Index", "N701", ""),
+            Q(i7_id="N701"),
+        )
+        self.assertEqual(
+            build_index_range_filter("i7_id", "I7 Index", "", "N701"),
+            Q(i7_id="N701"),
+        )
+
+    def test_index_range_filter_no_bounds_returns_none(self):
+        self.assertIsNone(build_index_range_filter("i7_id", "I7 Index", "", ""))
+
+    def test_index_range_filter_rejects_mismatched_prefix(self):
+        with self.assertRaises(InvalidIndexRangeError):
+            build_index_range_filter("i7_id", "I7 Index", "N701", "S508")
+
+    def test_index_range_filter_rejects_unparseable_bound(self):
+        with self.assertRaises(InvalidIndexRangeError):
+            build_index_range_filter("i7_id", "I7 Index", "N701", "custom-seq")
 
 
 class TestLibraries(BaseTestCase):

--- a/backend/library/views.py
+++ b/backend/library/views.py
@@ -1,3 +1,4 @@
+import re
 from collections import defaultdict
 from datetime import datetime
 from functools import reduce
@@ -101,6 +102,51 @@ def filter_by_sequencer(queryset, sequencer_id):
     )
 
 
+INDEX_ID_RE = re.compile(r"^([A-Za-z]+)(\d+)$")
+
+
+def parse_index_id(value):
+    """Split an index ID like 'N701' into its ('N', 701) prefix/number parts."""
+    match = INDEX_ID_RE.match(value)
+    if not match:
+        return None, None
+    prefix, number = match.groups()
+    return prefix, int(number)
+
+
+class InvalidIndexRangeError(Exception):
+    def __init__(self, field_label):
+        self.field_label = field_label
+        super().__init__(f"Invalid {field_label} range")
+
+
+def build_index_range_filter(field, field_label, from_val, to_val):
+    """Build a Q object for an I7/I5 ID range, or None if no range was requested.
+
+    Both ends given: IDs must share a letter prefix and end in a number, so the
+    range can be expanded into the literal IDs it covers (a plain string range
+    would misorder IDs like RPI2..RPI10 lexicographically). Only one end given:
+    exact match on that ID. Mismatched/unparsable prefixes raise
+    InvalidIndexRangeError rather than silently returning a wrong subset.
+    """
+    from_val = (from_val or "").strip()
+    to_val = (to_val or "").strip()
+
+    if not from_val and not to_val:
+        return None
+
+    if from_val and to_val:
+        from_prefix, from_number = parse_index_id(from_val)
+        to_prefix, to_number = parse_index_id(to_val)
+        if from_prefix is None or to_prefix is None or from_prefix != to_prefix:
+            raise InvalidIndexRangeError(field_label)
+        lo, hi = sorted((from_number, to_number))
+        candidates = [f"{from_prefix}{n}" for n in range(lo, hi + 1)]
+        return Q(**{f"{field}__in": candidates})
+
+    return Q(**{field: from_val or to_val})
+
+
 class LibrarySampleTree(viewsets.ViewSet):
     def list(self, request):
         search_string = request.GET.get("search")
@@ -109,6 +155,10 @@ class LibrarySampleTree(viewsets.ViewSet):
         analysis_type_filter = request.GET.get("analysis_type")
         sequencer_filter = request.GET.get("sequencer")
         read_length_filter = request.GET.get("read_length")
+        i7_from = request.GET.get("i7_from")
+        i7_to = request.GET.get("i7_to")
+        i5_from = request.GET.get("i5_from")
+        i5_to = request.GET.get("i5_to")
         start_date_str = request.GET.get("start_date")
         end_date_str = request.GET.get("end_date")
         page = int(request.GET.get("page", 1))
@@ -189,6 +239,29 @@ class LibrarySampleTree(viewsets.ViewSet):
             seq_id = int(sequencer_filter)
             library_queryset = filter_by_sequencer(library_queryset, seq_id)
             sample_queryset = filter_by_sequencer(sample_queryset, seq_id)
+
+        try:
+            i7_range_q = build_index_range_filter("i7_id", "I7 Index", i7_from, i7_to)
+            i5_range_q = build_index_range_filter("i5_id", "I5 Index", i5_from, i5_to)
+        except InvalidIndexRangeError as exc:
+            return Response(
+                {
+                    "success": False,
+                    "error": (
+                        f"{exc.field_label} range must share a prefix and end "
+                        "in a number, e.g. N701 to N729."
+                    ),
+                },
+                status=400,
+            )
+
+        if i7_range_q is not None:
+            library_queryset = library_queryset.filter(i7_range_q)
+            sample_queryset = sample_queryset.filter(i7_range_q)
+
+        if i5_range_q is not None:
+            library_queryset = library_queryset.filter(i5_range_q)
+            sample_queryset = sample_queryset.filter(i5_range_q)
 
         changed_ownership_filter = request.GET.get("changed_ownership")
 

--- a/frontend/src/assets/css/css_main.css
+++ b/frontend/src/assets/css/css_main.css
@@ -1291,13 +1291,15 @@ input[type="radio"]:checked::after {
   font-weight: bold;
 }
 
-.filter-item select {
+.filter-item select,
+.filter-item input[type="text"] {
   width: 100%;
   padding: 8px;
   border: 1px solid #ddd;
   border-end-start-radius: 8px;
   border-end-end-radius: 8px;
   background-color: white;
+  box-sizing: border-box;
 }
 
 .reset-button {

--- a/frontend/src/views/librariesAndSamplesView.vue
+++ b/frontend/src/views/librariesAndSamplesView.vue
@@ -188,6 +188,50 @@
               </select>
             </div>
 
+            <!-- I7 Index Range Filter -->
+            <div class="filter-item">
+              <label for="i7From">I7 Index (from)</label>
+              <input
+                type="text"
+                id="i7From"
+                placeholder="e.g. N701"
+                v-model="filters.i7From"
+                @change="getLibrariesSamples(1)"
+              />
+            </div>
+            <div class="filter-item">
+              <label for="i7To">I7 Index (to)</label>
+              <input
+                type="text"
+                id="i7To"
+                placeholder="e.g. N729"
+                v-model="filters.i7To"
+                @change="getLibrariesSamples(1)"
+              />
+            </div>
+
+            <!-- I5 Index Range Filter -->
+            <div class="filter-item">
+              <label for="i5From">I5 Index (from)</label>
+              <input
+                type="text"
+                id="i5From"
+                placeholder="e.g. S501"
+                v-model="filters.i5From"
+                @change="getLibrariesSamples(1)"
+              />
+            </div>
+            <div class="filter-item">
+              <label for="i5To">I5 Index (to)</label>
+              <input
+                type="text"
+                id="i5To"
+                placeholder="e.g. S522"
+                v-model="filters.i5To"
+                @change="getLibrariesSamples(1)"
+              />
+            </div>
+
             <!-- Reset Filters Button -->
             <button @click="resetAdvancedFilters" class="reset-button">
               Reset Filters
@@ -432,6 +476,13 @@
                       sequencer, read length, or changed ownership. These
                       filters are useful when you know what stage or processing
                       setup you are looking for.
+                    </li>
+                    <li>
+                      Use the <strong>I7 Index</strong> and
+                      <strong>I5 Index</strong> range filters under Advanced
+                      Filters to find libraries/samples by their index IDs (e.g.
+                      From <code>N701</code> To <code>N729</code>). Leave one
+                      side empty to match a single index exactly.
                     </li>
                     <li>
                       If the table looks too crowded, use
@@ -1519,7 +1570,11 @@ export default {
         analysisType: null,
         sequencer: null,
         readLength: null,
-        changedOwnership: null
+        changedOwnership: null,
+        i7From: "",
+        i7To: "",
+        i5From: "",
+        i5To: ""
       },
       protocolsList: [],
       analysisTypesList: [],
@@ -1657,6 +1712,18 @@ export default {
         }
         if (this.filters.changedOwnership !== null) {
           params.changed_ownership = this.filters.changedOwnership;
+        }
+        if (this.filters.i7From) {
+          params.i7_from = this.filters.i7From;
+        }
+        if (this.filters.i7To) {
+          params.i7_to = this.filters.i7To;
+        }
+        if (this.filters.i5From) {
+          params.i5_from = this.filters.i5From;
+        }
+        if (this.filters.i5To) {
+          params.i5_to = this.filters.i5To;
         }
 
         let response = await axiosRef.get(
@@ -1864,7 +1931,11 @@ export default {
         analysisType: null,
         sequencer: null,
         readLength: null,
-        changedOwnership: null
+        changedOwnership: null,
+        i7From: "",
+        i7To: "",
+        i5From: "",
+        i5To: ""
       };
       this.getLibrariesSamples(1);
     },


### PR DESCRIPTION
## Summary
- Adds dedicated **I7 Index** / **I5 Index** From/To range filters to the Libraries & Samples Advanced Filters panel, so users can find records by index ID range (e.g. `N701` to `N729`) instead of relying on an exact Index Type name substring match.
- Backend range parsing is numeric-aware (prefix + integer suffix), avoiding the lexicographic-sort trap where a plain string range on kits like `RPI1`-`RPI10` would incorrectly exclude `RPI2`..`RPI9`.
- If From/To don't share a prefix or don't parse as prefix+number, the API returns 400 with a clear message rather than silently returning a wrong/partial match. Leaving one side empty does an exact match on the other.
- Updated the in-app help modal and CHANGELOG.

## Test plan
- [x] Backend: `python manage.py test library.tests.TestLibrarySampleTree --keepdb` — 13/13 pass, including new tests for `parse_index_id`, `build_index_range_filter` (numeric range, reversed bounds, single-bound exact match, no-bounds, mismatched prefix, unparsable bound).
- [x] Frontend: `npm run build` succeeds with no errors.
- [x] Manual verification on parkour-dev (search a known I7/I5 range and confirm expected libraries/samples show up).