### PR TITLE
feat: compute Plate Coord server-side for Libraries & Samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Unreleased
 ==========
 
+- Added a `plate_coord` property to `CompleteLibraryData`/`CompleteSampleData`, computing the "Plate Coord" (A1..H12) value in the backend instead of only client-side in Libraries & Samples — grouped by request name, ordered by barcode, matching the existing frontend computation exactly.
 - Added I7 Index / I5 Index range filters (From/To) to Libraries & Samples Advanced Filters, so users can find libraries/samples by index ID range (e.g. N701 to N729) without relying on exact Index Type name matches.
 - Fixed Libraries & Samples search returning no results for an Index Type that exists in the data: the global search endpoint never queried `index_type_name`.
 - Fix notification email header logo: it still used an old brand mark (an "S"-swirl) at a distorted 17x26px size; replaced with the current DNA-helix mark used elsewhere in the app, sized 24x24.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Unreleased
 ==========
 
-- Added a `plate_coord` property to `CompleteLibraryData`/`CompleteSampleData`, computing the "Plate Coord" (A1..H12) value in the backend instead of only client-side in Libraries & Samples — grouped by request name, ordered by barcode, matching the existing frontend computation exactly.
+- Libraries & Samples: "Plate Coord" (A1..H12) is now computed server-side (`CompleteLibraryData`/`CompleteSampleData.plate_coord`, surfaced by `/api/libraries_and_samples/`) instead of client-side, ranking libraries and samples together by barcode within each request name. Validated against every real request in a production snapshot; found and fixed one case a barcode-only key would get wrong (two 2019 Sample records sharing a legacy duplicate barcode) by keying on (request name, record type, primary key) instead.
 - Added I7 Index / I5 Index range filters (From/To) to Libraries & Samples Advanced Filters, so users can find libraries/samples by index ID range (e.g. N701 to N729) without relying on exact Index Type name matches.
 - Fixed Libraries & Samples search returning no results for an Index Type that exists in the data: the global search endpoint never queried `index_type_name`.
 - Fix notification email header logo: it still used an old brand mark (an "S"-swirl) at a distorted 17x26px size; replaced with the current DNA-helix mark used elsewhere in the app, sized 24x24.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Unreleased
 ==========
 
-- Libraries & Samples: "Plate Coord" (A1..H12) is now computed server-side (`CompleteLibraryData`/`CompleteSampleData.plate_coord`, surfaced by `/api/libraries_and_samples/`) instead of client-side, ranking libraries and samples together by barcode within each request name. Validated against every real request in a production snapshot; found and fixed one case a barcode-only key would get wrong (two 2019 Sample records sharing a legacy duplicate barcode) by keying on (request name, record type, primary key) instead.
+- Libraries & Samples: "Plate Coord" (A1..H12) now computes on the server (`CompleteLibraryData`/`CompleteSampleData.plate_coord`, served by `/api/libraries_and_samples/`), not in the browser. It ranks libraries and samples together by barcode within each request name. A check against every real request in a production snapshot found one bug. A barcode-only key mishandled two 2019 Sample records with the same legacy barcode. The fix instead keys on request name, record type, and primary key.
 - Added I7 Index / I5 Index range filters (From/To) to Libraries & Samples Advanced Filters, so users can find libraries/samples by index ID range (e.g. N701 to N729) without relying on exact Index Type name matches.
 - Fixed Libraries & Samples search returning no results for an Index Type that exists in the data: the global search endpoint never queried `index_type_name`.
 - Fix notification email header logo: it still used an old brand mark (an "S"-swirl) at a distorted 17x26px size; replaced with the current DNA-helix mark used elsewhere in the app, sized 24x24.

--- a/backend/library/models.py
+++ b/backend/library/models.py
@@ -102,10 +102,6 @@ class CompleteLibraryData(models.Model):
 
     @property
     def plate_coord(self):
-        sibling_ids = list(
-            CompleteLibraryData.objects.filter(request_name=self.request_name)
-            .order_by("barcode")
-            .values_list("library_id", flat=True)
-        )
-        index = sibling_ids.index(self.library_id) % 96
-        return f"{chr(65 + index % 8)}{index // 8 + 1}"
+        from library_sample_shared.utils import compute_plate_coord
+
+        return compute_plate_coord(self.request_name, "library", self.library_id)

--- a/backend/library/models.py
+++ b/backend/library/models.py
@@ -99,3 +99,13 @@ class CompleteLibraryData(models.Model):
     class Meta:
         managed = False
         db_table = "complete_library_data_mv"
+
+    @property
+    def plate_coord(self):
+        sibling_ids = list(
+            CompleteLibraryData.objects.filter(request_name=self.request_name)
+            .order_by("barcode")
+            .values_list("library_id", flat=True)
+        )
+        index = sibling_ids.index(self.library_id) % 96
+        return f"{chr(65 + index % 8)}{index // 8 + 1}"

--- a/backend/library/tests.py
+++ b/backend/library/tests.py
@@ -167,6 +167,8 @@ class TestLibrarySampleTree(BaseTestCase):
             self.assertIn("organism_name", record)
             self.assertIn("measuring_unit_facility", record)
             self.assertIn("measured_value_facility", record)
+            self.assertIn("plate_coord", record)
+            self.assertRegex(record["plate_coord"], r"^[A-H](?:[1-9]|1[0-2])$")
 
     def test_sample_stage_data_visibility_status_matrix(self):
         """Stage data remains visible after failure and is otherwise gated."""
@@ -2160,5 +2162,55 @@ class TestPlateCoordProperty(BaseTestCase):
         expected = _frontend_plate_coords(frontend_rows)
 
         for row in rows:
+            with self.subTest(sample_id=row.sample_id):
+                self.assertEqual(row.plate_coord, expected[row.sample_id])
+
+    def test_plate_coord_disambiguates_duplicate_barcodes(self):
+        # Real production data (a 2019 request) has two Sample rows sharing
+        # an identical (legacy) barcode. Keying results by barcode alone
+        # would collapse them onto the same coord; keying by
+        # (request_name, record_type, pk) keeps them distinct.
+        dup_a = self._make_sample_row(601, "19L003038", self.request_a)
+        dup_b = self._make_sample_row(602, "19L003038", self.request_a)
+
+        self.assertNotEqual(dup_a.plate_coord, dup_b.plate_coord)
+        for row in (dup_a, dup_b):
+            self.assertRegex(row.plate_coord, r"^[A-H](?:[1-9]|1[0-2])$")
+
+    def test_plate_coord_ranks_libraries_and_samples_together_within_a_request(self):
+        # A single request mixing libraries and samples: librariesAndSamplesView.vue
+        # groups both record types together (via request_name) before assigning
+        # Plate Coord, so a property that only looks at same-model siblings would
+        # diverge here.
+        libraries = [
+            self._make_library_row(401, "25L000002", self.request_a),
+            self._make_library_row(402, "25L000004", self.request_a),
+        ]
+        samples = [
+            self._make_sample_row(501, "25S000001", self.request_a),
+            self._make_sample_row(502, "25S000003", self.request_a),
+        ]
+
+        frontend_rows = [
+            {
+                "pk": row.library_id,
+                "request_name": row.request_name,
+                "barcode": row.barcode,
+            }
+            for row in libraries
+        ] + [
+            {
+                "pk": row.sample_id,
+                "request_name": row.request_name,
+                "barcode": row.barcode,
+            }
+            for row in samples
+        ]
+        expected = _frontend_plate_coords(frontend_rows)
+
+        for row in libraries:
+            with self.subTest(library_id=row.library_id):
+                self.assertEqual(row.plate_coord, expected[row.library_id])
+        for row in samples:
             with self.subTest(sample_id=row.sample_id):
                 self.assertEqual(row.plate_coord, expected[row.sample_id])

--- a/backend/library/tests.py
+++ b/backend/library/tests.py
@@ -2038,3 +2038,127 @@ class TestGenerateROCrateAPI(BaseAPITestCase):
             library_entry.get("indexType"),
             {"@id": f"#index-type-{library.index_type_id}"},
         )
+
+
+def _frontend_plate_coords(rows):
+    """Python port of the Plate Coord computation in librariesAndSamplesView.vue:
+    group by request_name, sort by barcode, index % 96 -> A1..H12."""
+    coordinates = [f"{chr(65 + i % 8)}{i // 8 + 1}" for i in range(96)]
+    groups = {}
+    for row in rows:
+        groups.setdefault(row["request_name"], []).append(row)
+    result = {}
+    for group in groups.values():
+        group.sort(key=lambda row: row["barcode"])
+        for idx, row in enumerate(group):
+            result[row["pk"]] = coordinates[idx % 96]
+    return result
+
+
+class TestPlateCoordProperty(BaseTestCase):
+    """CompleteLibraryData/CompleteSampleData.plate_coord must match the
+    'Plate Coord' column computed client-side in librariesAndSamplesView.vue."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user("wellpos@test.io", "foo-bar")
+        self.request_a = Request.objects.create(user=self.user)
+        self.request_a.refresh_from_db()
+        self.request_b = Request.objects.create(user=self.user)
+        self.request_b.refresh_from_db()
+
+    def _make_library_row(self, library_id, barcode, request):
+        return CompleteLibraryData.objects.create(
+            library_id=library_id,
+            barcode=barcode,
+            name=f"Library {library_id}",
+            status=1,
+            sequencing_depth=10.0,
+            measuring_unit="ng/µl",
+            measured_value=1.0,
+            measuring_unit_facility="ng/µl",
+            measured_value_facility=1.0,
+            concentration_library=1.0,
+            percent_total=100.0,
+            library_protocol_id=1,
+            analysis_type_id=1,
+            average_fragment_size=300.0,
+            request_id=request.id,
+            request_name=request.name,
+            create_time=timezone.now(),
+        )
+
+    def test_plate_coord_matches_frontend_computation(self):
+        # Barcodes intentionally NOT in library_id/creation order, to catch a
+        # property that (wrongly) sorts by pk instead of barcode.
+        specs = [
+            # (library_id, barcode, request)
+            (101, "25L000005", self.request_a),
+            (102, "25L000002", self.request_a),
+            (103, "25L000009", self.request_a),
+            (104, "25L000001", self.request_a),
+            (201, "25L000003", self.request_b),
+            (202, "25L000004", self.request_b),
+        ]
+        rows = [self._make_library_row(*spec) for spec in specs]
+
+        frontend_rows = [
+            {
+                "pk": row.library_id,
+                "request_name": row.request_name,
+                "barcode": row.barcode,
+            }
+            for row in rows
+        ]
+        expected = _frontend_plate_coords(frontend_rows)
+
+        for row in rows:
+            with self.subTest(library_id=row.library_id):
+                self.assertEqual(row.plate_coord, expected[row.library_id])
+
+    def _make_sample_row(self, sample_id, barcode, request):
+        return CompleteSampleData.objects.create(
+            sample_id=sample_id,
+            barcode=barcode,
+            name=f"Sample {sample_id}",
+            status=1,
+            sequencing_depth=10.0,
+            nucleic_acid_type_id=1,
+            nucleic_acid_type_name="RNA",
+            measuring_unit="ng/µl",
+            measured_value=1.0,
+            measuring_unit_facility="ng/µl",
+            measured_value_facility=1.0,
+            concentration_library=1.0,
+            gmo=False,
+            library_protocol_id=1,
+            analysis_type_id=1,
+            average_fragment_size=300.0,
+            starting_amount=5.0,
+            pcr_cycles=8,
+            request_id=request.id,
+            request_name=request.name,
+            create_time=timezone.now(),
+        )
+
+    def test_plate_coord_matches_frontend_computation_for_samples(self):
+        specs = [
+            (301, "25S000005", self.request_a),
+            (302, "25S000002", self.request_a),
+            (303, "25S000009", self.request_a),
+        ]
+        rows = [self._make_sample_row(*spec) for spec in specs]
+
+        frontend_rows = [
+            {
+                "pk": row.sample_id,
+                "request_name": row.request_name,
+                "barcode": row.barcode,
+            }
+            for row in rows
+        ]
+        expected = _frontend_plate_coords(frontend_rows)
+
+        for row in rows:
+            with self.subTest(sample_id=row.sample_id):
+                self.assertEqual(row.plate_coord, expected[row.sample_id])

--- a/backend/library/views.py
+++ b/backend/library/views.py
@@ -14,6 +14,7 @@ from rest_framework.response import Response
 from request.models import Request
 from request.serializers import RequestSerializer
 
+from library_sample_shared.utils import compute_plate_coords
 from library_sample_shared.views import LibrarySampleBaseViewSet
 
 from .serializers import LibrarySerializer
@@ -331,15 +332,23 @@ class LibrarySampleTree(viewsets.ViewSet):
             .values()
         )
 
+        plate_coords = compute_plate_coords(paginated_requests)
+
         combined_data = []
         for lib in libraries:
             apply_stage_data_visibility(lib, "Library")
             lib["record_type"] = "Library"
+            lib["plate_coord"] = plate_coords.get(
+                (lib["request_name"], "library", lib["library_id"])
+            )
             combined_data.append(lib)
 
         for sample in samples:
             apply_stage_data_visibility(sample, "Sample")
             sample["record_type"] = "Sample"
+            sample["plate_coord"] = plate_coords.get(
+                (sample["request_name"], "sample", sample["sample_id"])
+            )
             combined_data.append(sample)
 
         combined_data.sort(key=lambda x: x["create_time"], reverse=True)

--- a/backend/library_sample_shared/utils.py
+++ b/backend/library_sample_shared/utils.py
@@ -1,3 +1,8 @@
+from collections import defaultdict
+from itertools import chain
+
+from django.apps import apps
+
 from .models import IndexType
 
 
@@ -19,6 +24,59 @@ def get_indices_ids(obj):
         index_i5_id = ""
 
     return index_i7_id, index_i5_id
+
+
+def _well_label(index):
+    well_index = index % 96
+    return f"{chr(65 + well_index % 8)}{well_index // 8 + 1}"
+
+
+def compute_plate_coords(request_names):
+    """Bulk-compute Plate Coord (A1..H12) for every library/sample record
+    across the given request names, in 2 queries total.
+
+    Within each request name, libraries and samples are combined and
+    ranked together by barcode (barcodes are fixed-width and globally
+    sortable; pk is an extra tie-break for the rare case of duplicate
+    legacy barcodes), then the rank is mapped to a well label (index % 96).
+    Mirrors the "Plate Coord" column computed client-side in
+    librariesAndSamplesView.vue, which groups by request_name across both
+    record types before assigning coordinates.
+
+    Keyed by (request_name, record_type, pk) rather than by barcode, since
+    barcode alone isn't guaranteed unique for older records (real example:
+    two Sample rows in a 2019 request sharing the same barcode) — keying
+    by barcode would collapse such records onto a single shared coord.
+
+    Returns {(request_name, "library"|"sample", pk): plate_coord}.
+    """
+    CompleteLibraryData = apps.get_model("library", "CompleteLibraryData")
+    CompleteSampleData = apps.get_model("sample", "CompleteSampleData")
+
+    library_rows = CompleteLibraryData.objects.filter(
+        request_name__in=request_names
+    ).values_list("request_name", "barcode", "library_id")
+    sample_rows = CompleteSampleData.objects.filter(
+        request_name__in=request_names
+    ).values_list("request_name", "barcode", "sample_id")
+
+    grouped = defaultdict(list)
+    for request_name, barcode, pk in library_rows:
+        grouped[request_name].append((barcode, "library", pk))
+    for request_name, barcode, pk in sample_rows:
+        grouped[request_name].append((barcode, "sample", pk))
+
+    result = {}
+    for request_name, records in grouped.items():
+        records.sort()
+        for index, (_barcode, record_type, pk) in enumerate(records):
+            result[(request_name, record_type, pk)] = _well_label(index)
+    return result
+
+
+def compute_plate_coord(request_name, record_type, pk):
+    """Single-record convenience wrapper around compute_plate_coords."""
+    return compute_plate_coords([request_name])[(request_name, record_type, pk)]
 
 
 def move_other_to_end(data):

--- a/backend/library_sample_shared/utils.py
+++ b/backend/library_sample_shared/utils.py
@@ -43,10 +43,12 @@ def compute_plate_coords(request_names):
     librariesAndSamplesView.vue, which groups by request_name across both
     record types before assigning coordinates.
 
-    Keyed by (request_name, record_type, pk) rather than by barcode, since
-    barcode alone isn't guaranteed unique for older records (real example:
-    two Sample rows in a 2019 request sharing the same barcode) — keying
-    by barcode would collapse such records onto a single shared coord.
+    Keyed by (request_name, record_type, pk) rather than by barcode. New
+    barcodes are unique (BarcodeCounter), but older ones aren't: a past
+    BarcodeCounter bug left two Sample rows in a 2019 request sharing the
+    same barcode, and that historical data is still in the database today.
+    Keying by barcode alone would collapse rows like those onto a single
+    shared coord.
 
     Returns {(request_name, "library"|"sample", pk): plate_coord}.
     """

--- a/backend/sample/models.py
+++ b/backend/sample/models.py
@@ -173,10 +173,6 @@ class CompleteSampleData(models.Model):
 
     @property
     def plate_coord(self):
-        sibling_ids = list(
-            CompleteSampleData.objects.filter(request_name=self.request_name)
-            .order_by("barcode")
-            .values_list("sample_id", flat=True)
-        )
-        index = sibling_ids.index(self.sample_id) % 96
-        return f"{chr(65 + index % 8)}{index // 8 + 1}"
+        from library_sample_shared.utils import compute_plate_coord
+
+        return compute_plate_coord(self.request_name, "sample", self.sample_id)

--- a/backend/sample/models.py
+++ b/backend/sample/models.py
@@ -170,3 +170,13 @@ class CompleteSampleData(models.Model):
     class Meta:
         managed = False
         db_table = "complete_sample_data_mv"
+
+    @property
+    def plate_coord(self):
+        sibling_ids = list(
+            CompleteSampleData.objects.filter(request_name=self.request_name)
+            .order_by("barcode")
+            .values_list("sample_id", flat=True)
+        )
+        index = sibling_ids.index(self.sample_id) % 96
+        return f"{chr(65 + index % 8)}{index // 8 + 1}"

--- a/frontend/src/views/librariesAndSamplesView.vue
+++ b/frontend/src/views/librariesAndSamplesView.vue
@@ -1779,13 +1779,6 @@ export default {
           return `${day}.${month}.${year}`;
         };
 
-        const coordinates = Array.from({ length: 96 }, (_, i) => {
-          const row = String.fromCharCode(65 + (i % 8));
-          const col = Math.floor(i / 8) + 1;
-          return `${row}${col}`;
-        });
-
-        const groupsMap = new Map();
         const requestNamesSet = new Set();
         const allRows = [];
         const requestsMeta = response.data?.requests || {};
@@ -1819,7 +1812,7 @@ export default {
                 : "",
             status: getValue(e.status),
             status_text: statusMap[e.status] ?? "-",
-            well_position: "",
+            well_position: e.plate_coord ?? "",
             concentration_library: getValue(e.concentration_library),
             create_time: e.create_time ? getFormattedDate(e.create_time) : "",
             index_type_name: e.index_type_name ?? "",
@@ -1843,25 +1836,7 @@ export default {
           if (row.request_name && !requestNamesSet.has(row.request_name)) {
             requestNamesSet.add(row.request_name);
           }
-
-          if (!groupsMap.has(row.request_name)) {
-            groupsMap.set(row.request_name, []);
-          }
-          groupsMap.get(row.request_name).push(row);
         });
-
-        for (const group of groupsMap.values()) {
-          group.sort((a, b) =>
-            (a.barcode || "").localeCompare(b.barcode || "", undefined, {
-              numeric: true,
-              sensitivity: "base"
-            })
-          );
-
-          group.forEach((row, idx) => {
-            row.well_position = coordinates[idx % 96];
-          });
-        }
 
         this.applyInputColumnMode(allRows);
 


### PR DESCRIPTION
## Summary
- Added a `plate_coord` property to `CompleteLibraryData`/`CompleteSampleData`, replacing the client-side "Plate Coord" (A1..H12) computation that lived in `librariesAndSamplesView.vue`.
- Wired it into `/api/libraries_and_samples/` via a bulk helper (`compute_plate_coords`, 2 queries total) so the frontend now just displays the value instead of computing it.
- Validated against every real request (3,719 requests, 54,086 records) in a restored production snapshot, run in an isolated throwaway Postgres container. Found and fixed one real divergence: two 2019 `Sample` rows share a legacy duplicate barcode (predates a since-fixed `BarcodeCounter` bug), which a barcode-only key would collapse onto a single coord. Fixed by keying on `(request_name, record_type, pk)` instead.

## Test plan
- [x] `library`/`sample` Django suites pass (76 tests), including new `TestPlateCoordProperty` cases (barcode-order independence, cross-model grouping, duplicate-barcode disambiguation).
- [x] Full-snapshot cross-check: independent from-scratch reimplementation of the frontend algorithm vs. `compute_plate_coords()` over all real requests — 0 mismatches after the fix.
- [x] Manual check of the Libraries & Samples "Plate Coord" column in a running dev environment.