### PR TITLE
feat: animate abrupt UI transitions in request editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Unreleased
 ==========
 
+- Request editor: saving overlay, confirm dialogs (switch record type, delete rows, close, delete file), and the left-panel collapse now animate smoothly instead of snapping instantly. (PR #347.)
 - Backend settings package renamed from `wui` to `config` (`DJANGO_SETTINGS_MODULE` is now `config.settings.*`); deployments/scripts setting that env var directly need updating. Also added an import-linter check enforcing that the shared `common` app never imports domain apps, catching one existing violation. (Direct commit `5cbc20a4`.)
 - Top nav bar buttons' corner rounding now matches the green header action buttons (Advanced Filters, Select Columns, Export to Excel, etc.) instead of using a fuller pill shape. (Direct commit `8075e97`.)
 - Fixed a fresh database migrate failing outright: the Analysis Type rename shipped without a migration for the model rename itself, and some apps had accumulated conflicting/duplicate migrations from unrelated work. (Direct commit `2d4b3de`.)

--- a/frontend/src/views/requestEditorView.vue
+++ b/frontend/src/views/requestEditorView.vue
@@ -5232,6 +5232,7 @@ export default {
   align-items: center;
   justify-content: center;
   z-index: 5;
+  animation: fade-in 0.15s ease-out;
 }
 
 .saving-card {
@@ -5246,6 +5247,7 @@ export default {
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
   font-size: 14px;
   color: #333;
+  animation: request-editor-pop-in 0.22s ease-out forwards;
 }
 
 .confirm-overlay {

--- a/frontend/src/views/requestEditorView.vue
+++ b/frontend/src/views/requestEditorView.vue
@@ -5258,6 +5258,7 @@ export default {
   align-items: center;
   justify-content: center;
   z-index: 1001;
+  animation: request-editor-fade-in 0.18s ease-out;
 }
 
 .confirm-modal {
@@ -5269,6 +5270,7 @@ export default {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  animation: request-editor-pop-in 0.22s ease-out forwards;
 }
 
 .owner-change-modal {

--- a/frontend/src/views/requestEditorView.vue
+++ b/frontend/src/views/requestEditorView.vue
@@ -5442,6 +5442,7 @@ export default {
   grid-template-rows: auto 1fr auto;
   --left-panel-width: 320px;
   --panel-toggle-width: 34px;
+  transition: grid-template-columns 0.2s ease;
 }
 
 .request-editor-content.collapsed {


### PR DESCRIPTION
## Summary
- Fade in the saving overlay/spinner card (reuses existing `fade-in`/`request-editor-pop-in` keyframes)
- Fade+pop in the confirm dialogs (switch type, delete, close, delete file)
- Smooth the left-panel collapse/expand width change

No new dependencies; all reuse existing CSS keyframes already defined for the request editor modal.

## Test plan
- [ ] Open new request editor, trigger save, confirm saving overlay fades in
- [ ] Trigger each confirm dialog (switch record type, delete rows, close, delete file), confirm fade+pop in
- [ ] Collapse/expand left panel, confirm smooth width transition