### PR TITLE
fix: coverage-target container reuse, missing extra/__init__.py, explorer wui->config paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -522,10 +522,10 @@ enable-explorer:
 	@docker exec parkour2-django python manage.py create_readonly_pg
 	@sed -i -e \
 		's%# \(path("explorer/", include("explorer.urls")),\)%\1%' \
-		backend/wui/urls.py
+		backend/config/urls.py
 	@sed -i -e \
 		's%# \("explorer",\)%\1%' \
-		backend/wui/settings/dev.py
+		backend/config/settings/dev.py
 	@$(MAKE) schema collect-static
 	@docker exec parkour2-django python manage.py create_sample_queries
 
@@ -536,10 +536,10 @@ disable-ollama:
 disable-explorer:
 	@sed -i -e \
 		's%^\(\s*\)\(path("explorer/", include("explorer.urls")),\)%\1# \2%' \
-		backend/wui/urls.py
+		backend/config/urls.py
 	@sed -i -e \
 		's%^\(\s*\)\("explorer",\)%\1# \2%' \
-		backend/wui/settings/dev.py
+		backend/config/settings/dev.py
 
 # aider:
 # 	@export OPENROUTER_API_KEY=$$(grep OPENROUTER_API_KEY misc/parkour.env.ignore | cut -d'=' -f2)

--- a/Makefile
+++ b/Makefile
@@ -333,10 +333,22 @@ create-admin:
 		"DJANGO_SUPERUSER_PASSWORD=testing.password DJANGO_SUPERUSER_EMAIL=test.user@test.com \
 			python manage.py createsuperuser --no-input"
 
-coverage-xml: down set-testing deploy-webapp
+coverage-xml:  ## Run coverage (xml report), reuse running container when available
+	@if docker compose ps --status running --services | grep -q '^parkour2-django$$'; then \
+		echo "Info: Reusing running parkour2-django container for coverage."; \
+	else \
+		echo "Info: parkour2-django is not running, redeploying test stack first."; \
+		$(MAKE) down set-testing deploy-webapp; \
+	fi
 	@docker compose exec parkour2-django pytest -n auto --cov=./ --cov-config=.coveragerc --cov-report=xml
 
-coverage-html: down set-testing deploy-webapp
+coverage-html:  ## Run coverage (html report), reuse running container when available
+	@if docker compose ps --status running --services | grep -q '^parkour2-django$$'; then \
+		echo "Info: Reusing running parkour2-django container for coverage."; \
+	else \
+		echo "Info: parkour2-django is not running, redeploying test stack first."; \
+		$(MAKE) down set-testing deploy-webapp; \
+	fi
 	@docker compose exec parkour2-django coverage erase
 	@docker compose exec parkour2-django coverage run -m pytest -n auto --cov=./ --cov-config=.coveragerc --cov-report=html
 


### PR DESCRIPTION
## Summary
- `backend/extra/` was missing `__init__.py` (other app dirs like `request/`, `invoicing/` have one), breaking `extra/test_middleware.py`'s relative import and collection under pytest.
- `coverage-xml`/`coverage-html` Makefile targets always tore down and redeployed the test stack; now reuse a running `parkour2-django` container first, matching `djtest`'s pattern.
- `enable-explorer`/`disable-explorer` Makefile targets still referenced `backend/wui/...` after the wui->config settings rename (5cbc20a4); updated to `backend/config/...`.

## Test plan
- [x] `make coverage-html` runs clean, 342 tests pass, no collection errors
- [x] Coverage report generates (84.08% overall)