### PR TITLE
fix: complete wui->config rename left broken on develop

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -125,7 +125,7 @@ jobs:
 
       - name: Verify migrations
         env:
-          DJANGO_SETTINGS_MODULE: wui.settings.prod
+          DJANGO_SETTINGS_MODULE: config.settings.prod
           DATABASE_URL: postgres://postgres:${{ secrets.POSTGRES_PASSWORD }}@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/postgres
           SECRET_KEY: ${{ secrets.SECRET_KEY }}
         run: |
@@ -134,7 +134,7 @@ jobs:
 
       - name: Validate templates
         env:
-          DJANGO_SETTINGS_MODULE: wui.settings.prod
+          DJANGO_SETTINGS_MODULE: config.settings.prod
           DATABASE_URL: postgres://postgres:${{ secrets.POSTGRES_PASSWORD }}@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/postgres
           SECRET_KEY: ${{ secrets.SECRET_KEY }}
         run: |
@@ -143,7 +143,7 @@ jobs:
 
       - name: Run unittests
         env:
-          DJANGO_SETTINGS_MODULE: wui.settings.testing
+          DJANGO_SETTINGS_MODULE: config.settings.testing
           DATABASE_URL: postgres://postgres:${{ secrets.POSTGRES_PASSWORD }}@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/postgres
           SECRET_KEY: ${{ secrets.SECRET_KEY }}
         run: |

--- a/backend.Dockerfile
+++ b/backend.Dockerfile
@@ -55,15 +55,15 @@ ENV PATH="/opt/ro-crate-html-js/node_modules/.bin:${PATH}"
 COPY ./backend .
 
 EXPOSE 8000
-ENV DJANGO_SETTINGS_MODULE=wui.settings.prod
-CMD ["gunicorn", "wui.wsgi:application", "--bind=0.0.0.0:8000", "--name=pk2", "--timeout=600", \
+ENV DJANGO_SETTINGS_MODULE=config.settings.prod
+CMD ["gunicorn", "config.wsgi:application", "--bind=0.0.0.0:8000", "--name=pk2", "--timeout=600", \
     "--worker-class=gthread", "--worker-tmp-dir=/dev/shm", "--workers=4", "--threads=6"]
 
 # ----------------------
 FROM pk2_base AS pk2_dev
 RUN echo "from functools import partial\nimport rich\nhelp = partial(rich.inspect, help=True, methods=True)" \
     > /root/.pythonrc
-ENV DJANGO_SETTINGS_MODULE=wui.settings.dev \
+ENV DJANGO_SETTINGS_MODULE=config.settings.dev \
     PYTHONSTARTUP=/root/.pythonrc \
     PYTHONDEVMODE=0 \
     PYTHONBREAKPOINT=ipdb.set_trace \
@@ -75,7 +75,7 @@ CMD ["python", "/usr/src/app/manage.py", "runserver_plus", "--threaded", "0.0.0.
 
 # ----------------------
 FROM pk2_dev AS pk2_testing
-ENV DJANGO_SETTINGS_MODULE=wui.settings.testing
+ENV DJANGO_SETTINGS_MODULE=config.settings.testing
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install -r requirements/${PyVersion}/testing.txt
 ## e2e/playwright runs hit this over real concurrent requests -- runserver_plus
@@ -83,7 +83,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ## reliably even threaded, and caused intermittent session/auth failures under
 ## xdist parallelism. Serve with the same gunicorn setup as prod instead;
 ## nothing here needs live-reload.
-CMD ["gunicorn", "wui.wsgi:application", "--bind=0.0.0.0:8000", "--name=pk2", "--timeout=600", \
+CMD ["gunicorn", "config.wsgi:application", "--bind=0.0.0.0:8000", "--name=pk2", "--timeout=600", \
     "--worker-class=gthread", "--worker-tmp-dir=/dev/shm", "--workers=4", "--threads=6", \
     "--access-logfile=-"]
 

--- a/backend/.coveragerc
+++ b/backend/.coveragerc
@@ -5,8 +5,8 @@ omit =
     **/migrations/*.py
     manage.py
     __init__.py
-    wui/settings/*.py
-    wui/wsgi.py
+    config/settings/*.py
+    config/wsgi.py
 
 [report]
 ignore_errors = True

--- a/backend/common/urls.py
+++ b/backend/common/urls.py
@@ -56,7 +56,6 @@ router.register(
 urlpatterns = [
     path("", views.index, name="index"),
     path("get_navigation_tree/", views.get_navigation_tree, name="get_navigation_tree"),
-    path("media/<path:url_path>", views.protected_media, name="protected_media"),
     path(
         "login/", auth_views.LoginView.as_view(template_name="login.html"), name="login"
     ),

--- a/backend/common/views.py
+++ b/backend/common/views.py
@@ -1,8 +1,5 @@
 import json
-from mimetypes import guess_type
 import os
-from os.path import basename
-from urllib.parse import quote
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -11,11 +8,10 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.mail import send_mail
 from django.db.models import Q
-from django.http import Http404, HttpResponse, JsonResponse, FileResponse
+from django.http import JsonResponse, FileResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from django.utils import timezone
-from request.models import Request
 from rest_framework import status, viewsets
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import action
@@ -144,54 +140,6 @@ def get_navigation_tree(request):
         ]
 
     return JsonResponse({"text": ".", "children": data})
-
-
-@login_required
-def protected_media(request, *args, **kwargs):
-    """Protected view for media files"""
-
-    allow_download = False
-    url_path = kwargs["url_path"]
-
-    if request.user.is_staff:
-        allow_download = True
-    elif request.user.is_pi:
-        # Master/ PI accounts should be able to access attachments
-        allow_download = (
-            request.user.pi
-            == Request.objects.filter(
-                Q(deep_seq_request=url_path) | Q(files__file=url_path), archived=False
-            )[0].user.pi
-        )
-    else:
-        allow_download = Request.objects.filter(
-            Q(deep_seq_request=url_path) | Q(files__file=url_path),
-            user=request.user,
-            archived=False,
-        ).exists()
-
-    if allow_download:
-        response = HttpResponse()
-
-        # Set file type and encoding
-        mimetype, encoding = guess_type(url_path)
-        response["Content-Type"] = mimetype if mimetype else "application/octet-stream"
-        if encoding:
-            response["Content-Encoding"] = encoding
-
-        # Set internal redirect to protected media
-        response["X-Accel-Redirect"] = f"/protected_media/{url_path}"
-
-        # Set file name
-        file_name = basename(url_path)
-        # Needed for file names that include special, non ascii, characters
-        response["Content-Disposition"] = (
-            f"attachment; filename*=utf-8''{quote(file_name)}"
-        )
-
-        return response
-
-    raise Http404
 
 
 class CostUnitsViewSet(viewsets.ReadOnlyModelViewSet):

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "wui.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 
     from django.core.management import execute_from_command_line
 

--- a/backend/request/views.py
+++ b/backend/request/views.py
@@ -2,8 +2,10 @@ import itertools
 import json
 import logging
 import os
+from mimetypes import guess_type
+from os.path import basename
 from unicodedata import normalize
-from urllib.parse import urlencode
+from urllib.parse import quote, urlencode
 
 from common.mviews import refresh_batched
 from common.serializers import UserSerializer
@@ -12,6 +14,7 @@ from common.views import CsrfExemptSessionAuthentication, StandardResultsSetPagi
 from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.contrib.auth.decorators import login_required
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.mail import send_mail
 from django.db import transaction
@@ -1065,3 +1068,51 @@ class ApproveViewSet(viewsets.ModelViewSet):
                 recipient_list=_recipient_list_with_sender_copy(recipient_email),
             )
         return HttpResponseRedirect("/danke")
+
+
+@login_required
+def protected_media(request, *args, **kwargs):
+    """Protected view for media files"""
+
+    allow_download = False
+    url_path = kwargs["url_path"]
+
+    if request.user.is_staff:
+        allow_download = True
+    elif request.user.is_pi:
+        # Master/ PI accounts should be able to access attachments
+        allow_download = (
+            request.user.pi
+            == Request.objects.filter(
+                Q(deep_seq_request=url_path) | Q(files__file=url_path), archived=False
+            )[0].user.pi
+        )
+    else:
+        allow_download = Request.objects.filter(
+            Q(deep_seq_request=url_path) | Q(files__file=url_path),
+            user=request.user,
+            archived=False,
+        ).exists()
+
+    if allow_download:
+        response = HttpResponse()
+
+        # Set file type and encoding
+        mimetype, encoding = guess_type(url_path)
+        response["Content-Type"] = mimetype if mimetype else "application/octet-stream"
+        if encoding:
+            response["Content-Encoding"] = encoding
+
+        # Set internal redirect to protected media
+        response["X-Accel-Redirect"] = f"/protected_media/{url_path}"
+
+        # Set file name
+        file_name = basename(url_path)
+        # Needed for file names that include special, non ascii, characters
+        response["Content-Disposition"] = (
+            f"attachment; filename*=utf-8''{quote(file_name)}"
+        )
+
+        return response
+
+    raise Http404

--- a/backend/requirements/3.10/dev.txt
+++ b/backend/requirements/3.10/dev.txt
@@ -31,6 +31,8 @@ cffi==2.1.1 ; platform_python_implementation != 'PyPy'
     # via cryptography
 charset-normalizer==3.5.1
     # via requests
+click==8.5.0
+    # via import-linter
 colorama==0.4.6 ; sys_platform == 'win32'
     # via ipython
 contourpy==1.3.2 ; python_full_version < '3.11'
@@ -150,6 +152,8 @@ fpdf2==2.8.8
     # via
     #   -c backend/requirements/3.10/base.txt
     #   -r backend/requirements/base.in
+grimp==3.17
+    # via import-linter
 gunicorn==26.2.0
     # via
     #   -c backend/requirements/3.10/base.txt
@@ -167,6 +171,8 @@ idna==3.19
     #   anyio
     #   httpx2
     #   requests
+import-linter==2.15
+    # via -r backend/requirements/dev.in
 inflection==0.5.1
     # via
     #   -c backend/requirements/3.10/base.txt
@@ -313,7 +319,9 @@ requests==2.34.2
     #   django-sql-explorer
     #   tiktoken
 rich==15.0.0
-    # via -r backend/requirements/dev.in
+    # via
+    #   -r backend/requirements/dev.in
+    #   import-linter
 rpds-py==0.30.0 ; python_full_version < '3.11'
     # via
     #   -c backend/requirements/3.10/base.txt
@@ -357,7 +365,9 @@ tiktoken==0.14.0
 toml==0.10.2
     # via django-migration-linter
 tomli==2.4.1 ; python_full_version < '3.11'
-    # via ipdb
+    # via
+    #   import-linter
+    #   ipdb
 traitlets==5.16.1
     # via
     #   ipython
@@ -374,6 +384,7 @@ typing-extensions==4.16.0
     #   cryptography
     #   exceptiongroup
     #   httpx2
+    #   import-linter
     #   ipython
     #   openai
     #   pydantic

--- a/backend/requirements/3.11/dev.txt
+++ b/backend/requirements/3.11/dev.txt
@@ -31,6 +31,8 @@ cffi==2.1.1 ; platform_python_implementation != 'PyPy'
     # via cryptography
 charset-normalizer==3.5.1
     # via requests
+click==8.5.0
+    # via import-linter
 colorama==0.4.6 ; sys_platform == 'win32'
     # via ipython
 contourpy==1.3.3
@@ -142,6 +144,8 @@ fpdf2==2.8.8
     # via
     #   -c backend/requirements/3.11/base.txt
     #   -r backend/requirements/base.in
+grimp==3.17
+    # via import-linter
 gunicorn==26.2.0
     # via
     #   -c backend/requirements/3.11/base.txt
@@ -159,6 +163,8 @@ idna==3.19
     #   anyio
     #   httpx2
     #   requests
+import-linter==2.15
+    # via -r backend/requirements/dev.in
 inflection==0.5.1
     # via
     #   -c backend/requirements/3.11/base.txt
@@ -301,7 +307,9 @@ requests==2.34.2
     #   django-sql-explorer
     #   tiktoken
 rich==15.0.0
-    # via -r backend/requirements/dev.in
+    # via
+    #   -r backend/requirements/dev.in
+    #   import-linter
 rpds-py==2026.6.3
     # via
     #   -c backend/requirements/3.11/base.txt
@@ -352,6 +360,7 @@ typing-extensions==4.16.0
     #   -c backend/requirements/3.11/base.txt
     #   anyio
     #   httpx2
+    #   import-linter
     #   ipython
     #   openai
     #   pydantic

--- a/backend/requirements/3.12/dev.txt
+++ b/backend/requirements/3.12/dev.txt
@@ -31,6 +31,8 @@ cffi==2.1.1 ; platform_python_implementation != 'PyPy'
     # via cryptography
 charset-normalizer==3.5.1
     # via requests
+click==8.5.0
+    # via import-linter
 colorama==0.4.6 ; sys_platform == 'win32'
     # via ipython
 contourpy==1.3.3
@@ -142,6 +144,8 @@ fpdf2==2.8.8
     # via
     #   -c backend/requirements/3.12/base.txt
     #   -r backend/requirements/base.in
+grimp==3.17
+    # via import-linter
 gunicorn==26.2.0
     # via
     #   -c backend/requirements/3.12/base.txt
@@ -159,6 +163,8 @@ idna==3.19
     #   anyio
     #   httpx2
     #   requests
+import-linter==2.15
+    # via -r backend/requirements/dev.in
 inflection==0.5.1
     # via
     #   -c backend/requirements/3.12/base.txt
@@ -285,7 +291,9 @@ requests==2.34.2
     #   django-sql-explorer
     #   tiktoken
 rich==15.0.0
-    # via -r backend/requirements/dev.in
+    # via
+    #   -r backend/requirements/dev.in
+    #   import-linter
 rpds-py==2026.6.3
     # via
     #   -c backend/requirements/3.12/base.txt
@@ -336,6 +344,7 @@ typing-extensions==4.16.0
     #   -c backend/requirements/3.12/base.txt
     #   anyio
     #   httpx2
+    #   import-linter
     #   openai
     #   pydantic
     #   pydantic-core

--- a/backend/requirements/3.13/dev.txt
+++ b/backend/requirements/3.13/dev.txt
@@ -31,6 +31,8 @@ cffi==2.1.1 ; platform_python_implementation != 'PyPy'
     # via cryptography
 charset-normalizer==3.5.1
     # via requests
+click==8.5.0
+    # via import-linter
 colorama==0.4.6 ; sys_platform == 'win32'
     # via ipython
 contourpy==1.3.3
@@ -142,6 +144,8 @@ fpdf2==2.8.8
     # via
     #   -c backend/requirements/3.13/base.txt
     #   -r backend/requirements/base.in
+grimp==3.17
+    # via import-linter
 gunicorn==26.2.0
     # via
     #   -c backend/requirements/3.13/base.txt
@@ -159,6 +163,8 @@ idna==3.19
     #   anyio
     #   httpx2
     #   requests
+import-linter==2.15
+    # via -r backend/requirements/dev.in
 inflection==0.5.1
     # via
     #   -c backend/requirements/3.13/base.txt
@@ -285,7 +291,9 @@ requests==2.34.2
     #   django-sql-explorer
     #   tiktoken
 rich==15.0.0
-    # via -r backend/requirements/dev.in
+    # via
+    #   -r backend/requirements/dev.in
+    #   import-linter
 rpds-py==2026.6.3
     # via
     #   -c backend/requirements/3.13/base.txt
@@ -335,6 +343,7 @@ typing-extensions==4.16.0
     # via
     #   -c backend/requirements/3.13/base.txt
     #   anyio
+    #   import-linter
     #   openai
     #   pydantic
     #   pydantic-core

--- a/backend/requirements/dev.in
+++ b/backend/requirements/dev.in
@@ -7,6 +7,7 @@ Werkzeug
 rich
 django-migration-linter
 django-schema-viewer
+import-linter
 django-sql-explorer
 openai
 sql_metadata


### PR DESCRIPTION
## Summary
develop is currently broken -- `config/urls.py` imports `protected_media`
from `request.views`, but `5cbc20a4` (settings package rename wui->config)
never actually moved that function there despite its commit message
claiming it did. It's still only in `common/views.py`/`common/urls.py`,
and `config/urls.py` fails to import on any fresh checkout.

Also completes the same rename in files 5cbc20a4 missed:
- `backend.Dockerfile`: 3 build targets (prod/dev/testing) still set
  `DJANGO_SETTINGS_MODULE=wui.settings.*` and run `wui.wsgi:application`
- `backend/manage.py`: default settings module fallback still `wui.settings`
- `backend/.coveragerc`: omit paths still reference `wui/`
- `backend/requirements/*/dev.txt`, `dev.in`: missing `import-linter` pin
  (5cbc20a4 added the import-linter contract in `setup.cfg` but never
  pinned the package itself)

## Test plan
- [x] `python -c "import ast; ast.parse(...)"` on touched files
- [x] CI (this PR should go green where develop currently fails)